### PR TITLE
Fix bug in dataset_utils.fragments_to_dataset

### DIFF
--- a/xdlake/dataset_utils.py
+++ b/xdlake/dataset_utils.py
@@ -55,7 +55,7 @@ def fragments_to_dataset(fragments: list[pa.Table | pa.RecordBatch], schema_mode
     """
     schemas = defaultdict(list)
     for frag in fragments:
-        schemas[frag.schema].append(frag)
+        schemas[frag.schema.remove_metadata()].append(frag)
 
     datasets = [pa.dataset.dataset(frags) for frags in schemas.values()]
 


### PR DESCRIPTION
This is due to unhashable content in pyarrow Schema when derived from a pandas schema. Maybe don't try to use schemas as dict keys?